### PR TITLE
fix(history): don't parse tool_result as ItemStartedEvent in deferred dequeue

### DIFF
--- a/source/cydo/app.d
+++ b/source/cydo/app.d
@@ -3332,27 +3332,42 @@ class App : ToolsBackend
 				{
 					if (ta.isUserMessageLine(line))
 					{
-						// Non-compacted: type:"user" echo present — pass through with
-						// the enqueue UUID injected (always override any existing uuid so
-						// that undo truncates at the enqueue line, not the echo line).
-						auto savedEnqueueLineNum = lastDequeuedEnqueueLineNum;
-						lastDequeuedText = null;
-						lastDequeuedEnqueueLineNum = 0;
 						auto ts = ta.translateHistoryLine(line, lineNum);
-							if (ts.length > 0)
-							{
-								import std.format : format;
-								auto enqueueUuid = format!"enqueue-%d"(savedEnqueueLineNum);
-								// Inject enqueue UUID into the first event (item/started type=user_message).
-								import cydo.agent.protocol : ItemStartedEvent;
-								auto ev = jsonParse!ItemStartedEvent(ts[0].translated);
-								// Only steering echoes should use enqueue-N as the visible anchor.
-								// Regular user turns keep the raw user UUID.
-								if (ev.is_steering)
-									ev.uuid = enqueueUuid;
-								return stripTransientStatus([TranslatedEvent(toJson(ev), ts[0].raw)] ~ ts[1 .. $]);
-							}
-						return [];
+						// a type:"user" JSONL line translates to either an
+						// item/started user_message (the steering echo we're waiting
+						// for) or an item/result (a tool_result that landed while the
+						// turn was mid-tool-use). only the former is the dequeued echo;
+						// parsing an item/result as ItemStartedEvent throws on its
+						// tool_result field, so peek at the type first
+						bool firstIsItemStarted = false;
+						if (ts.length > 0)
+						{
+							@JSONPartial static struct TypeProbe { string type; }
+							firstIsItemStarted =
+								jsonParse!TypeProbe(ts[0].translated).type == "item/started";
+						}
+						if (firstIsItemStarted)
+						{
+							// non-compacted: echo present — pass through with the
+							// enqueue UUID injected (always override any existing uuid
+							// so undo truncates at the enqueue line, not the echo line)
+							auto savedEnqueueLineNum = lastDequeuedEnqueueLineNum;
+							lastDequeuedText = null;
+							lastDequeuedEnqueueLineNum = 0;
+							import std.format : format;
+							auto enqueueUuid = format!"enqueue-%d"(savedEnqueueLineNum);
+							// inject enqueue UUID into the first event (item/started type=user_message)
+							import cydo.agent.protocol : ItemStartedEvent;
+							auto ev = jsonParse!ItemStartedEvent(ts[0].translated);
+							// only steering echoes should use enqueue-N as the visible anchor;
+							// regular user turns keep the raw user UUID
+							if (ev.is_steering)
+								ev.uuid = enqueueUuid;
+							return stripTransientStatus([TranslatedEvent(toJson(ev), ts[0].raw)] ~ ts[1 .. $]);
+						}
+						// not the echo (tool_result, or empty translation): pass
+						// through unchanged and stay deferred for the real echo
+						return stripTransientStatus(ts);
 					}
 					if (ta.isAssistantMessageLine(line))
 					{


### PR DESCRIPTION
## Problem

Opening a task whose history has a steering message immediately followed by a `tool_result` crashes the server with an uncaught `object.Exception` (exit 1). `ensureHistoryLoaded` throws on every click, so the task's history never loads.

Abbreviated stack trace:

```
object.Exception@ae/utils/serialization/serialization.d(1007): Unknown field tool_result
  ... jsonParse!(cydo.agent.protocol.ItemStartedEvent) ...
  source/cydo/app.d  (ensureHistoryLoaded, deferred-dequeue branch)
```

## Root cause

In the deferred-dequeue branch, after a queue `dequeue` the code treats the next `type:"user"` line as the steering echo and parses it strictly as `ItemStartedEvent`. But when the turn was interrupted mid-tool-use, that line is a `tool_result`, which `translateHistoryLine` turns into an `item/result` event whose `tool_result` field `ItemStartedEvent` doesn't declare. `ItemStartedEvent` is parsed strictly, so the unknown field throws and the exception is uncaught.

## Fix

Peek at the translated event's `type` with a `@JSONPartial` probe and only run the `ItemStartedEvent` parse/inject path when it's `item/started`. Otherwise emit the translated events unchanged and stay deferred for the real echo. `ItemStartedEvent` is left strict so round-tripping an `item/result` through it can't silently drop `tool_result`.

## Repro

A Claude history file with these three lines; open the task in the UI:

```json
{"type":"queue-operation","operation":"enqueue","timestamp":"2026-06-11T06:00:00Z","sessionId":"S","content":"are you under control?"}
{"type":"queue-operation","operation":"dequeue","timestamp":"2026-06-11T06:00:01Z","sessionId":"S"}
{"parentUuid":"p","isSidechain":false,"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"ok"}]}}
```
