### PR TITLE
fix(claude): omit --model in completeOneShot when alias resolves empty

### DIFF
--- a/source/cydo/agent/drivers/claude.d
+++ b/source/cydo/agent/drivers/claude.d
@@ -604,27 +604,22 @@ class ClaudeCodeAgent : Agent
 			"HOME": environment.get("HOME", ""),
 		];
 
-		string[] args;
+		auto model = resolveModelAlias(modelClass);
+		string[] args = [
+			claudeBin,
+			"-p", prompt,
+			"--output-format", "text",
+			"--max-turns", "1",
+			"--tools", "",
+			"--no-session-persistence",
+		];
+		// an empty alias means no explicit model; omit the flag so claude
+		// falls back to its own configured default, matching the session
+		// spawn path's `config.model.length > 0` guard
+		if (model.length > 0)
+			args ~= ["--model", model];
 		if (launch.cmdPrefix !is null)
-			args = launch.cmdPrefix ~ [
-				claudeBin,
-				"-p", prompt,
-				"--output-format", "text",
-				"--model", resolveModelAlias(modelClass),
-				"--max-turns", "1",
-				"--tools", "",
-				"--no-session-persistence",
-			];
-		else
-			args = [
-				claudeBin,
-				"-p", prompt,
-				"--output-format", "text",
-				"--model", resolveModelAlias(modelClass),
-				"--max-turns", "1",
-				"--tools", "",
-				"--no-session-persistence",
-			];
+			args = launch.cmdPrefix ~ args;
 
 		auto procEnv = launch.cmdPrefix is null ? env : null;
 

--- a/source/cydo/agent/drivers/claude.d
+++ b/source/cydo/agent/drivers/claude.d
@@ -586,6 +586,42 @@ class ClaudeCodeAgent : Agent
 		return RewindResult(true, result.output);
 	}
 
+	private static string[] buildOneShotArgs(string claudeBin, string prompt,
+		string model, ProcessLaunch launch)
+	{
+		string[] args = [
+			claudeBin,
+			"-p", prompt,
+			"--output-format", "text",
+			"--max-turns", "1",
+			"--tools", "",
+			"--no-session-persistence",
+		];
+		// an empty alias means no explicit model; omit the flag so claude
+		// falls back to its own configured default, matching the session
+		// spawn path's `config.model.length > 0` guard
+		if (model.length > 0)
+			args ~= ["--model", model];
+		if (launch.cmdPrefix !is null)
+			args = launch.cmdPrefix ~ args;
+		return args;
+	}
+
+	unittest
+	{
+		import std.algorithm : canFind, countUntil;
+
+		ProcessLaunch launch; // .init: no cmdPrefix
+
+		// an empty alias must omit --model entirely; the bug emitted `--model ""`
+		assert(!buildOneShotArgs("claude", "hi", "", launch).canFind("--model"));
+
+		// a resolved model is passed through as `--model <x>`
+		auto withModel = buildOneShotArgs("claude", "hi", "opus", launch);
+		auto i = withModel.countUntil("--model");
+		assert(i >= 0 && withModel[i + 1] == "opus");
+	}
+
 	OneShotHandle completeOneShot(string prompt, string modelClass,
 		ProcessLaunch launch = ProcessLaunch.init)
 	{
@@ -605,21 +641,7 @@ class ClaudeCodeAgent : Agent
 		];
 
 		auto model = resolveModelAlias(modelClass);
-		string[] args = [
-			claudeBin,
-			"-p", prompt,
-			"--output-format", "text",
-			"--max-turns", "1",
-			"--tools", "",
-			"--no-session-persistence",
-		];
-		// an empty alias means no explicit model; omit the flag so claude
-		// falls back to its own configured default, matching the session
-		// spawn path's `config.model.length > 0` guard
-		if (model.length > 0)
-			args ~= ["--model", model];
-		if (launch.cmdPrefix !is null)
-			args = launch.cmdPrefix ~ args;
+		auto args = buildOneShotArgs(claudeBin, prompt, model, launch);
 
 		auto procEnv = launch.cmdPrefix is null ? env : null;
 


### PR DESCRIPTION
## Problem

`completeOneShot` (title generation) passes `--model resolveModelAlias(modelClass)` unconditionally. An empty `model_aliases` entry makes `resolveModelAlias` return `""`, so it runs `claude --model ""` and fails with `API Error 400` ("String should have at least 1 character"), surfacing as `failed to generate title: claude exited with status 1`. The session-spawn path already guards this (`config.model.length > 0`); `completeOneShot` is the one spot that doesn't.

## Motivation

After Fable 5 was shut down I wanted cydo to stop pinning a model and instead defer to `claude`'s own configured default, so it would fall back gracefully rather than stay pointed at an unavailable model. The way to express that is empty `model_aliases` entries, but that config wasn't actually runnable: `completeOneShot` passed `--model ""` and broke title generation on the next cydo task I started. This PR's change is what makes the empty-alias / defer-to-claude config work end to end.

## Fix

Append `--model` only when the resolved model is non-empty (matching the session-spawn guard), and collapse the duplicated `cmdPrefix` / non-`cmdPrefix` arg lists into one.
