### PR TITLE
feat(claude): trust the project of a permission_policy "allow" task

### DIFF
--- a/source/cydo/agent/drivers/claude.d
+++ b/source/cydo/agent/drivers/claude.d
@@ -692,6 +692,97 @@ class ClaudeCodeAgent : Agent
 	}
 }
 
+/// Path to the Claude Code config file the spawned `claude` child reads
+/// (honors CLAUDE_CONFIG_DIR, else ~/.claude.json).
+private string claudeJsonPath()
+{
+	import std.path : buildPath, expandTilde;
+	import std.process : environment;
+	auto dir = environment.get("CLAUDE_CONFIG_DIR", "");
+	return dir.length > 0 ? buildPath(dir, ".claude.json") : buildPath(expandTilde("~"), ".claude.json");
+}
+
+/// Mark `projectPath` as a trusted project in Claude Code's config
+/// (projects[projectPath].hasTrustDialogAccepted = true). Run non-interactively
+/// (cydo's `-p` mode), Claude leaves a directory untrusted and silently ignores
+/// its settings.local.json `permissions.allow` entries and project hooks; trust
+/// is keyed per-directory, so each project a task runs in needs its own flag.
+/// Idempotent and atomic: merges into the existing config, writes (temp + rename)
+/// only when the flag is missing, and never throws into session launch.
+private void ensureProjectTrusted(string projectPath, string claudeConfigPath)
+{
+	import std.file : exists, read, rename, write;
+	import std.json : JSONValue, JSONType, parseJSON;
+	import std.logger : warningf;
+
+	if (projectPath.length == 0)
+		return;
+	try
+	{
+		JSONValue root = exists(claudeConfigPath)
+			? parseJSON(cast(string) read(claudeConfigPath))
+			: parseJSON("{}");
+		if (root.type != JSONType.object)
+			return;
+
+		JSONValue[string] projects;
+		if (auto p = "projects" in root.object)
+			if (p.type == JSONType.object)
+				projects = p.object.dup;
+
+		JSONValue proj = parseJSON("{}");
+		if (auto existing = projectPath in projects)
+			if (existing.type == JSONType.object)
+				proj = *existing;
+		if (auto t = "hasTrustDialogAccepted" in proj.object)
+			if (t.type == JSONType.true_)
+				return; // already trusted
+
+		proj.object["hasTrustDialogAccepted"] = JSONValue(true);
+		projects[projectPath] = proj;
+		root.object["projects"] = JSONValue(projects);
+
+		// atomic: write a sibling temp file, then rename over the original
+		auto tmp = claudeConfigPath ~ ".cydo-trust-tmp";
+		write(tmp, root.toString());
+		rename(tmp, claudeConfigPath);
+	}
+	catch (Exception e)
+		warningf("ensureProjectTrusted: could not update %s: %s", claudeConfigPath, e.msg);
+}
+
+unittest
+{
+	import std.file : exists, mkdirRecurse, rmdirRecurse, read, write, tempDir;
+	import std.path : buildPath;
+	import std.json : JSONType, parseJSON;
+
+	auto dir = buildPath(tempDir(), "cydo-project-trust-unittest");
+	if (exists(dir))
+		rmdirRecurse(dir);
+	mkdirRecurse(dir);
+	scope(exit) rmdirRecurse(dir);
+
+	auto cfg = buildPath(dir, "claude.json");
+	// pre-existing config: an unrelated key plus a sibling project already
+	// trusted, to prove the merge preserves rather than clobbers
+	write(cfg, `{"oauthAccount":{"id":1},"projects":{"/other/proj":{"hasTrustDialogAccepted":true}}}`);
+
+	ensureProjectTrusted("/ws/project", cfg);
+
+	auto root = parseJSON(cast(string) read(cfg));
+	// the target project is now trusted
+	assert(root["projects"]["/ws/project"]["hasTrustDialogAccepted"].type == JSONType.true_);
+	// pre-existing content survives the merge
+	assert(root["oauthAccount"]["id"].integer == 1);
+	assert(root["projects"]["/other/proj"]["hasTrustDialogAccepted"].type == JSONType.true_);
+
+	// idempotent: a second run neither errors nor regresses the flag
+	ensureProjectTrusted("/ws/project", cfg);
+	auto again = parseJSON(cast(string) read(cfg));
+	assert(again["projects"]["/ws/project"]["hasTrustDialogAccepted"].type == JSONType.true_);
+}
+
 /// Claude Code session using stream-json protocol.
 class ClaudeCodeSession : AgentSession
 {
@@ -758,6 +849,12 @@ class ClaudeCodeSession : AgentSession
 			args = cmdPrefix ~ claudeArgs;
 		else
 			args = claudeArgs;
+
+		// a workspace set to auto-allow every tool call is already trusted; tell
+		// Claude so, since in -p mode it otherwise treats the dir as untrusted and
+		// drops its settings.local.json allow-list and hooks. keyed per-directory.
+		if (config.permissionPolicy == "allow" && config.workDir.length > 0)
+			ensureProjectTrusted(config.workDir, claudeJsonPath());
 
 		process = new AgentProcess(args, logName: "claude");
 


### PR DESCRIPTION
## Problem

A recent Claude Code version added a per-workspace "trust" gate. When `claude` runs non-interactively (the `-p` / stream-json mode cydo uses) it can't show the interactive trust dialog, so it treats the working directory as untrusted and silently drops that project's `settings.local.json` `permissions.allow` entries (and its project hooks), printing:

```
Ignoring 31 permissions.allow entries from .claude/settings.local.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog, or set projects["/path/to/workspace"].hasTrustDialogAccepted: true in ~/.claude.json.
```

This affects every cydo task, because cydo always runs non-interactively. Three things make it awkward to handle from outside cydo:

- `--dangerously-skip-permissions` (which cydo already passes) bypasses the permission *checks*, but not the trust layer, so tools still run while the allow-list and hooks stay ignored.
- There is no CLI flag to grant trust. The only non-interactive mechanism Claude documents is the `projects[<dir>].hasTrustDialogAccepted: true` key in `~/.claude.json` named in the message above.
- Trust is keyed per-directory and is not hierarchical: trusting a parent directory does not trust its children, so a workspace whose tasks run in several project directories needs each of them trusted independently.

## Approach

When launching a claude session whose workspace `permission_policy` is `"allow"`, mark that task's working directory as a trusted project in `~/.claude.json`.

Keying this off `permission_policy: "allow"` is deliberate: a workspace configured to auto-allow every tool call is already an explicit statement that the operator trusts it, so reflecting that intent into Claude's trust store is consistent with the existing configuration rather than a separate trust knob. Firing at session launch against the exact directory the session runs in trusts precisely the projects tasks actually enter (including project-discovery subdirectories) and nothing speculative.

## Safety

The write is idempotent and atomic. It reads the existing config, returns immediately if the directory is already trusted, and otherwise merges the single flag in and writes via a temp file plus rename so the file is never left half-written. Because it only writes when the flag is genuinely missing, it becomes a no-op read after the first launch in a given project, which keeps the unavoidable window where it races Claude's own writes to `~/.claude.json` as small as possible. Any failure is caught and logged; it never throws into session launch.

## Limitations

- It keys off the literal `permission_policy == "allow"`; a Djinja-expression policy that resolves to allow per-call won't trigger it, since the policy isn't reduced to a single value at the session level.
- For a sandboxed workspace whose HOME or paths are remapped, the host-side write and the `workDir` path may not match what the sandboxed `claude` sees. This targets the common case of unsandboxed allow/trusted workspaces.
- Claude-only; Codex and Copilot have no equivalent gate.

## Test

A hermetic unit test (temp paths) covers the merge: the target directory becomes trusted, an unrelated key and an already-trusted sibling project both survive (merge, not clobber), and a second run is idempotent.