### PR TITLE
test(e2e): remove both machine-speed failure modes from the suite

### DIFF
--- a/tests/mock-api/copilot-proxy.mjs
+++ b/tests/mock-api/copilot-proxy.mjs
@@ -252,7 +252,7 @@ function handleChatCompletions(socket, body) {
       { id: chatId, object: "chat.completion.chunk", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: JSON.stringify(first.input) } }] }, finish_reason: null }] },
       { id: chatId, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
       "[DONE]",
-    ]);
+    ], intent.delay ?? 0);
   } else {
     // tool_call — translate mcp__cydo__Foo → cydo-Foo for copilot's MCP tool registry
     let toolName = intent.name;
@@ -265,8 +265,9 @@ function handleChatCompletions(socket, body) {
       { id: chatId, object: "chat.completion.chunk", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: JSON.stringify(intent.input) } }] }, finish_reason: null }] },
       { id: chatId, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
       "[DONE]",
-    // Let the real client deliver Answer before its canonical idle event.
-    ], toolName === "cydo-Answer" ? 500 : 0);
+    // Let the real client deliver Answer before its canonical idle event,
+    // and honor an intent delay (ANSWER_DELAY_MS) whenever it is larger.
+    ], Math.max(intent.delay ?? 0, toolName === "cydo-Answer" ? 500 : 0));
   }
 }
 

--- a/tests/mock-api/patterns.mjs
+++ b/tests/mock-api/patterns.mjs
@@ -1,6 +1,13 @@
 // Shared pattern matching module for mock API servers.
 // Imported by server.mjs (Claude/Codex) and copilot-proxy.mjs (Copilot).
 
+// An instant Answer collapses the answerer-focused UI state to ~75ms on an
+// idle machine (faster than Playwright's visibility polling can observe), so
+// specs asserting the intermediate focus time out on a page that already moved
+// on correctly. Every Answer response carries this delay so the transient
+// state lasts long enough to be testable.
+export const ANSWER_DELAY_MS = 400;
+
 // Match a user text against known patterns and return a structured intent.
 // Returns one of:
 //   { type: "text", text: string }
@@ -76,6 +83,7 @@ export function matchPattern(userText) {
     if (m)
       return {
         type: "multi_tool_call",
+        delay: ANSWER_DELAY_MS,
         tool_calls: [
           {
             name: "mcp__cydo__Answer",
@@ -96,6 +104,7 @@ export function matchPattern(userText) {
     if (m)
       return {
         type: "tool_call",
+        delay: ANSWER_DELAY_MS,
         name: "mcp__cydo__Answer",
         input: { qid: parseInt(m[1]), message: "follow-up-answered" },
       };
@@ -105,6 +114,7 @@ export function matchPattern(userText) {
     if (m)
       return {
         type: "tool_call",
+        delay: ANSWER_DELAY_MS,
         name: "mcp__cydo__Answer",
         input: { qid: parseInt(m[1]), message: "non-direct-answer" },
       };
@@ -142,6 +152,7 @@ export function matchPattern(userText) {
     if (m)
       return {
         type: "tool_call",
+        delay: ANSWER_DELAY_MS,
         name: "mcp__cydo__Answer",
         input: { qid: parseInt(m[1]), message: "switch-mode-answer" },
       };
@@ -348,6 +359,7 @@ export function matchPattern(userText) {
   if (match)
     return {
       type: "tool_call",
+      delay: ANSWER_DELAY_MS,
       name: "mcp__cydo__Answer",
       input: { qid: parseInt(match[1]), message: match[2].trim() },
     };

--- a/tests/mock-api/server.mjs
+++ b/tests/mock-api/server.mjs
@@ -82,6 +82,17 @@ function streamTextResponse(res, text, model = "claude-sonnet-4-20250514") {
   res.end();
 }
 
+// Honor an intent's delay (e.g. ANSWER_DELAY_MS on Answer patterns) before
+// streaming its response. Cleared if the client disconnects first.
+function respondAfterIntentDelay(res, intent, respond) {
+  if (intent?.delay) {
+    const timer = setTimeout(respond, intent.delay);
+    res.on("close", () => clearTimeout(timer));
+  } else {
+    respond();
+  }
+}
+
 function streamToolUseResponse(
   res,
   toolName,
@@ -938,7 +949,9 @@ function handleResponses(req, res) {
       // Codex doesn't support MCP + shell calls in parallel, and the
       // deferral mechanism is exercised even with a single Answer call.
       const first = intent.tool_calls[0];
-      oaiStreamFunctionCallResponse(res, first.name, first.input);
+      respondAfterIntentDelay(res, intent, () =>
+        oaiStreamFunctionCallResponse(res, first.name, first.input),
+      );
     } else if (intent.type === "autonomous_compaction_switchmode") {
       oaiStreamFunctionCallResponse(
         res,
@@ -952,7 +965,9 @@ function handleResponses(req, res) {
       oaiStreamWebSearchCallResponse(res, intent.query, [intent.query]);
     } else {
       // tool_call — names are already correct for the OpenAI/Codex protocol
-      oaiStreamFunctionCallResponse(res, intent.name, intent.input);
+      respondAfterIntentDelay(res, intent, () =>
+        oaiStreamFunctionCallResponse(res, intent.name, intent.input),
+      );
     }
   });
 }
@@ -1347,7 +1362,9 @@ function handleMessages(req, res) {
     } else if (intent.type === "multi_tool_call") {
       const toolNames = intent.tool_calls.map((tc) => tc.name);
       const inputs = intent.tool_calls.map((tc) => tc.input);
-      streamMultiToolUseResponse(res, toolNames, inputs, model);
+      respondAfterIntentDelay(res, intent, () =>
+        streamMultiToolUseResponse(res, toolNames, inputs, model),
+      );
     } else if (intent.type === "eager_ask") {
       streamEagerAskThenSlowToolResponse(
         res,
@@ -1375,19 +1392,14 @@ function handleMessages(req, res) {
         model,
       );
     } else if (intent.type === "shell" || intent.type === "background_shell") {
-      const respond = () =>
+      respondAfterIntentDelay(res, intent, () =>
         streamToolUseResponse(
           res,
           "Bash",
           { command: intent.command, description: "Running command" },
           model,
-        );
-      if (intent.delay) {
-        const timer = setTimeout(respond, intent.delay);
-        res.on("close", () => clearTimeout(timer));
-      } else {
-        respond();
-      }
+        ),
+      );
     } else {
       // tool_call — map generic names to Anthropic tool names
       let toolName = intent.name;
@@ -1399,7 +1411,9 @@ function handleMessages(req, res) {
         toolName = "Read";
         input = { file_path: intent.input.path };
       }
-      streamToolUseResponse(res, toolName, input, model);
+      respondAfterIntentDelay(res, intent, () =>
+        streamToolUseResponse(res, toolName, input, model),
+      );
     }
   });
 }


### PR DESCRIPTION
**Update (2026-09-05):** the wall-clock half below landed on master as 1b8410cf; this PR now carries only the idle-machine half (the Answer delay).

This removes both of the suite's machine-speed failure modes: assertions whose wall-clock bounds fire under parallel-build contention (a loaded machine), and assertions on transient UI states that a fast idle machine passes through more quickly than Playwright can observe. The two have opposite load profiles, which is much of why the flakiness looked random.

## Loaded machine: wall-clock bounds

Every check derivation runs one Playwright test, and nix builds them massively in parallel (max-jobs), so tests always execute on a heavily contended machine. Per-assertion timeouts were sized to idle-machine performance (the 5s Playwright default through 90s), which turns correctness assertions into de facto performance assertions: under contention the awaited condition still becomes true, but the clock fires first.

**Evidence that the wait time is real and the conditions do occur** (accounting per your bar for timeout changes):

- Every historically flaky check passes in 2-8 seconds when run alone; their failure durations cluster exactly at their timeout values (60s waits fail at 1.1m, 90s at 1.6m, etc.).
- The worst offenders are the multi-agent tests: e.g. `project-memory` performs two serial agent CLI cold starts (parent plus spawned subtask); under 32-wide contention, node cold starts alone exceed the 60s budget.
- Before this change, every full `nix flake check` sweep failed 2-10 of the same ~18 cells. After it: **zero timeout-class failures across ~1300 test executions** (two full ~600-check sweeps at full parallelism, plus four forced-rebuild rounds of the historical 18-cell flaky set running concurrently).

**The change** removes per-assertion wall-clock bounds as a class instead of bumping individual values: assertions and condition waits share one generous budget (9 minutes, via the `expect`/`actionTimeout`/`navigationTimeout` defaults and a page default timeout in the fixture), and the test timeout (10 minutes) becomes a pure hang detector rather than a performance expectation. Condition waits return the moment they are satisfied, so **passing runs are exactly as fast as before**; only genuine failures report slower. Explicit backend/mock readiness probes deliberately keep tight budgets, so a broken world still fails fast.

## Idle machine: transient focus states

The ask flow focuses the answering task while a question is delivered and focuses back when the answer returns. The mock answered instantly, so the answerer-focused sidebar state lasted about 75ms on an idle machine, less than Playwright's visibility polling can reliably observe, and every spec asserting the intermediate focus timed out on a page that had already moved on correctly. That inverts the timeout class's profile: these specs failed near-deterministically in serial runs on a quiet machine while passing under wide parallelism, where contention stretched the round trip into observability.

Answer responses now carry a 400ms delay (`ANSWER_DELAY_MS` in `patterns.mjs`), honored by all three protocol emulations before the tool call streams, so the focused state comfortably outlives the polling interval. Mechanism details and measurements are in [this comment on #19](https://github.com/CyberShadow/CyDo/pull/19#issuecomment-5448265025). With the delay in place, forced serial re-runs of the previously failing family on an idle machine pass deterministically.

**What this deliberately does not fix** (and instead makes visible): running the suite surfaced genuinely intermittent defects that were previously camouflaged as fast timeout flakes and cleared by re-running. Now they fail unambiguously, burning the full budget with the condition never occurring:

- `ask-answer.spec.ts:330` sometimes fails a synchronous ordering assertion (`activeIndex` = -1): the waiting-to-active status transition is missed by the test's event capture. No timeout is involved.
- `diff-result-toggle.spec.ts:9` occasionally never renders the diff at all, even on an idle machine.
- Under sustained all-e2e contention, an agent turn occasionally wedges entirely (never completes, and teardown hangs too), suggesting a process-level failure under load.

These look like worthwhile follow-ups; this PR only removes the timeout anti-pattern so they stop hiding among false failures.

Tested with two full `nix flake check` sweeps plus the rebuild rounds described above; the four contention-wedge failures observed during one sweep all pass on re-run (2-5s solo).