### PR TITLE
fix(web): skip history replacements whose target seq is absent

### DIFF
--- a/web/src/sessionReducer.test.ts
+++ b/web/src/sessionReducer.test.ts
@@ -296,18 +296,17 @@ describe("history boundary replacement", () => {
     expect(next.replacementEvents.get(4)).toEqual(replacement);
   });
 
-  it("rejects invalid replacement targets", () => {
+  it("skips replacements whose target seq is absent", () => {
     const state = makeState();
-    expect(() =>
-      replaceHistoryBoundary(
-        state,
-        {
-          type: "turn/stop",
-          history_boundary: { anchor: "a", kind: "agent_turn" },
-        },
-        4,
-      ),
-    ).toThrow("matched 0");
+    const next = replaceHistoryBoundary(
+      state,
+      {
+        type: "turn/stop",
+        history_boundary: { anchor: "a", kind: "agent_turn" },
+      },
+      4,
+    );
+    expect(next).toBe(state);
   });
 
   it("rejects mismatched canonical identity", () => {

--- a/web/src/sessionReducer.ts
+++ b/web/src/sessionReducer.ts
@@ -858,6 +858,16 @@ export function replaceHistoryBoundary(
         (message.seq === seq ||
           (Array.isArray(message.seq) && message.seq.includes(seq))),
     );
+  if (matches.length === 0) {
+    // A replacement can reference a message this client doesn't have: a live
+    // boundary racing a still-streaming history load, or a boundary persisted
+    // under an older seq numbering. Dropping it degrades one message's
+    // replacement; throwing would wedge the whole session view on every load.
+    console.error(
+      `History replacement matched 0 messages at seq ${seq}; skipping`,
+    );
+    return s;
+  }
   if (matches.length !== 1)
     throw new Error(
       `History replacement matched ${matches.length} messages at seq ${seq}`,


### PR DESCRIPTION
`replaceHistoryBoundary` throws when a replace-style boundary event references a message seq the client's reduced state does not contain. Two ways to get there in practice:

- a live boundary broadcast racing a still-streaming history load (the flush path's `pendingHistoryBoundaries` defer only guards the separately-routed `task_history_boundary_replaced` kind; boundary-carrying events flowing through `handleTaskMessage` reach the reducer unguarded), and
- a boundary persisted under an older seq numbering, replayed against a session whose seqs no longer line up. Observed on a large compacted session (7400+ events) after updating across the recent history refactors: every load threw `History replacement matched 0 messages at seq 7433`, which permanently wedged the session view at "Loading session..." with no recovery short of code changes.

Since the throw converts a cosmetic inconsistency into an unviewable session, this makes the matched-0 case fail soft: drop the replacement with a console diagnostic and return the state unchanged. The cost is one message rendering without its replacement until seqs realign. The structural invariants keep throwing (multiple matches, canonical-identity mismatch), and the replay flush path's defer behavior is unchanged; this only aligns the reducer's own behavior for the paths that have no defer queue.

The existing "rejects invalid replacement targets" test pinned the throw; it now asserts the skip returns the same state instance. Full `nix flake check` suite is green on the branch.