### PR TITLE
fix(web): show attachments in session-start framed messages

### DIFF
--- a/web/src/components/MessageList.test.tsx
+++ b/web/src/components/MessageList.test.tsx
@@ -455,6 +455,45 @@ describe("MessageList task diagnostics", () => {
     expect(html).toContain("The latest turn could not be loaded.");
   });
 
+  it("renders attachments inside a session-start framed message", () => {
+    const framed: DisplayMessage = {
+      id: "cydo-start-1",
+      uuid: "start-uuid-1",
+      type: "user",
+      isMeta: true,
+      content: [
+        { type: "text", text: "SYSTEM rendered prompt body" },
+        { type: "image", data: "aGVsbG8=", media_type: "image/png" },
+      ],
+      cydoMeta: {
+        label: "Session start: blank",
+        vars: { task_description: "what is in this picture?" },
+        bodyVar: "task_description",
+      },
+    };
+
+    const html = renderToString(
+      <MessageList
+        taskTid={1}
+        messages={[framed]}
+        blocks={new Map()}
+        replacementEvents={new Map()}
+        isProcessing={false}
+        bandStatus=""
+      />,
+    );
+
+    // the framed view must keep the attachment visible, not just the text:
+    // losing it on replay made a briefly-shown image vanish from the task
+    expect(html).toContain("user-image");
+    expect(html).toContain("data:image/png;base64,aGVsbG8=");
+    expect(html).toContain("what is in this picture?");
+    // attachment above the prompt, matching plain user messages
+    expect(html.indexOf("data:image/png")).toBeLessThan(
+      html.indexOf("what is in this picture?"),
+    );
+  });
+
   it("keeps a metadata-bearing CyDo nudge editable", () => {
     const nudge: DisplayMessage = {
       id: "cydo-nudge-1",

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -218,6 +218,28 @@ function SystemUserMessage({ message }: { message: DisplayMessage }) {
     .map((b) => b.text)
     .join("\n");
 
+  // Attachments survive the session-start framing (the backend keeps image
+  // blocks beside the rendered prompt), so they must survive its rendering
+  // too; the optimistic plain user message showed them, and losing them on
+  // replay looked like the attachment vanished.
+  const imageBlocks = message.content.filter(
+    (b): b is { type: "image"; data: string; media_type: string } =>
+      b.type === "image" &&
+      typeof (b as Record<string, unknown>).data === "string",
+  );
+  const images = imageBlocks.length > 0 && (
+    <div class="user-images">
+      {imageBlocks.map((img, i) => (
+        <img
+          key={i}
+          src={`data:${img.media_type};base64,${img.data}`}
+          alt="User attached image"
+          class="user-image"
+        />
+      ))}
+    </div>
+  );
+
   const hasVars = meta.vars && Object.keys(meta.vars).length > 0;
 
   if (!hasVars) {
@@ -262,6 +284,7 @@ function SystemUserMessage({ message }: { message: DisplayMessage }) {
         }}
       >
         <div class="system-user-header">{meta.label}</div>
+        {images}
         <pre class="system-user-pre">{text}</pre>
       </div>
     );
@@ -297,6 +320,7 @@ function SystemUserMessage({ message }: { message: DisplayMessage }) {
         </svg>
         {meta.label}
       </div>
+      {images}
       {bodyValue !== undefined && (
         <div class="system-user-body">
           {meta.bodyMarkdown ? (


### PR DESCRIPTION
A task's first message renders through the session-start framing (the label header, the body variable, and the "Full message" expander). That renderer extracted only the text blocks from the message content, so image blocks were dropped from the display.

The visible effect: an attachment on a task's first message appears briefly (the optimistic plain user message renders it) and then vanishes when the framed canonical message replaces it on history replay. The attachment itself is fine throughout: the backend keeps image blocks beside the rendered prompt and the model receives them; only the framed rendering lost them.

The fix renders the image blocks in both framed branches, above the prompt text in each (below the label header), using the same markup and ordering as the plain user message: attachments first, then text. Display-only, so previously affected messages recover on their next history load with no re-send.

A regression test renders a framed message carrying an image block and asserts both that the attachment appears and that it appears above the body text.

`nix flake check`: full set built; four integration checks failed under parallel load and passed serially (a disjoint set from other recent runs of the suite, so load-related rather than related to this change).