### PR TITLE
fix(tasks): survive the JSONL-fallback undo of a live Codex session

### DIFF
--- a/source/cydo/workflow/sessions/task_runner.d
+++ b/source/cydo/workflow/sessions/task_runner.d
@@ -784,6 +784,14 @@ public:
 		td = requireTask(tid, "Task disappeared before session creation");
 		auto session = taskAgent.createSession(tid, td.agentSessionId,
 			launch.processLaunch, launch.sessionConfig);
+		// A binding belongs to whichever session is currently mapped. Replacing
+		// the session (a pre-send respawn, a resume racing a still-exiting
+		// process) drops the old one here: the exiting session's onExit sees
+		// itself superseded and returns without cleaning up, which would
+		// otherwise leave a binding whose owner no longer matches and make
+		// every later history resolution throw. The new session installs its
+		// own once it announces its native session id.
+		liveHistoryBindings_.remove(tid);
 		sessions_[tid] = session;
 		host_.clearLastActive(tid);
 		session.onNativeSessionStarted = (string sessionId) {

--- a/source/cydo/workflow/tasks/mutations.d
+++ b/source/cydo/workflow/tasks/mutations.d
@@ -1070,8 +1070,19 @@ private:
 
 				write(jsonlPathSnap, jsonlSnap);
 			}
-			performUndoExecution(ws, tid, json, boundary, mechanism, access,
-				liveLaunch, false);
+			// the promise chain ends in ignoreResult, so a throw out of the
+			// undo would vanish; report it instead of dying silently with the
+			// session already stopped
+			try
+				performUndoExecution(ws, tid, json, boundary, mechanism, access,
+					liveLaunch, false);
+			catch (Exception e)
+			{
+				import std.logger : warningf;
+				warningf("undo: execution failed for task %d: %s", tid, e.msg);
+				ws.send(Data(toJson(ErrorMessage("error",
+					"Undo failed: " ~ e.msg, tid)).representation));
+			}
 		}).ignoreResult();
 		host_.stopTask(tid);
 	}
@@ -1136,44 +1147,65 @@ private:
 					});
 					return;
 				}
-				auto destination = host_.prepareHistoryForkDestination(tid);
-				auto backup = forkTask(*host_.persistence(), tid, access,
-					lastForkId, td.projectPath, td.workspace, td.title, destination,
-					&ta.rewriteSessionId, &ta.forkIdMatchesLine,
-					td.description, td.taskType, td.agentName);
-				if (backup.tid >= 0)
+				// The pre-undo backup is auxiliary: a driver that cannot
+				// provide a generic fork destination (Codex routes generic
+				// forks through the native thread RPC, which a busy live
+				// session cannot serve) skips the backup rather than aborting
+				// the undo.
+				HistoryForkDestination destination;
+				bool haveDestination;
+				try
 				{
-					if (td.worktreeTid > 0)
-						host_.persistence().setWorktreeTid(backup.tid, td.worktreeTid);
-					auto bTd = TaskData(backup.tid, td.workspace, td.projectPath);
-					bTd.title = td.title.length > 0 ? td.title ~ " (pre-undo)" : "(pre-undo)";
-					bTd.agentSessionId = backup.agentSessionId;
-					bTd.parentTid = tid;
-					bTd.relationType = "undo-backup";
-					bTd.status = TaskStatus.completed;
-					bTd.agentName = td.agentName;
-					bTd.description = td.description;
-					bTd.taskType = td.taskType;
-					bTd.worktreeTid = td.worktreeTid;
-					bTd.createdAt = Clock.currStdTime;
-					bTd.lastActive = bTd.createdAt;
-					host_.setRelationType(backup.tid, "undo-backup");
-					host_.setTitle(backup.tid, bTd.title);
-					host_.putTask(backup.tid, move(bTd));
-					auto backupTd = host_.getTask(backup.tid);
-					assert(backupTd !is null,
-						"Undo backup task must exist after insertion");
-					backupTd.processQueue = new StateQueue!ProcessState(
-						host_.makeProcessQueueSF(backup.tid),
-						ProcessState.Dead,
-					);
-					backupTd.archiveQueue = new StateQueue!ArchiveState(
-						host_.makeArchiveQueueSF(backup.tid),
-						ArchiveState.Unarchived,
-					);
-					backupTd.history.reset(watermarkFromPath(backup.destinationPath));
-					host_.broadcastTaskCreated(TaskCreatedMessage("task_created",
-						backup.tid, td.workspace, td.projectPath, tid, "undo-backup"));
+					destination = host_.prepareHistoryForkDestination(tid);
+					haveDestination = true;
+				}
+				catch (Exception e)
+				{
+					import std.logger : warningf;
+					warningf("undo: skipping pre-undo backup for task %d: %s",
+						tid, e.msg);
+				}
+				if (haveDestination)
+				{
+					auto backup = forkTask(*host_.persistence(), tid, access,
+						lastForkId, td.projectPath, td.workspace, td.title, destination,
+						&ta.rewriteSessionId, &ta.forkIdMatchesLine,
+						td.description, td.taskType, td.agentName);
+					if (backup.tid >= 0)
+					{
+						if (td.worktreeTid > 0)
+							host_.persistence().setWorktreeTid(backup.tid, td.worktreeTid);
+						auto bTd = TaskData(backup.tid, td.workspace, td.projectPath);
+						bTd.title = td.title.length > 0 ? td.title ~ " (pre-undo)" : "(pre-undo)";
+						bTd.agentSessionId = backup.agentSessionId;
+						bTd.parentTid = tid;
+						bTd.relationType = "undo-backup";
+						bTd.status = TaskStatus.completed;
+						bTd.agentName = td.agentName;
+						bTd.description = td.description;
+						bTd.taskType = td.taskType;
+						bTd.worktreeTid = td.worktreeTid;
+						bTd.createdAt = Clock.currStdTime;
+						bTd.lastActive = bTd.createdAt;
+						host_.setRelationType(backup.tid, "undo-backup");
+						host_.setTitle(backup.tid, bTd.title);
+						host_.putTask(backup.tid, move(bTd));
+						auto backupTd = host_.getTask(backup.tid);
+						assert(backupTd !is null,
+							"Undo backup task must exist after insertion");
+						backupTd.processQueue = new StateQueue!ProcessState(
+							host_.makeProcessQueueSF(backup.tid),
+							ProcessState.Dead,
+						);
+						backupTd.archiveQueue = new StateQueue!ArchiveState(
+							host_.makeArchiveQueueSF(backup.tid),
+							ArchiveState.Unarchived,
+						);
+						backupTd.history.reset(watermarkFromPath(backup.destinationPath));
+						host_.broadcastTaskCreated(TaskCreatedMessage("task_created",
+							backup.tid, td.workspace, td.projectPath, tid, "undo-backup"));
+
+				}
 					host_.broadcastTaskUpdate(backup.tid);
 				}
 			}


### PR DESCRIPTION
Undoing at a user message while a Codex turn is in flight goes down the JSONL-fallback path (native undo requires an idle thread). That path now fails twice over, and the `undo-while-running` e2e fails with it.

The first failure is at the pre-undo backup: it asks the driver for a generic fork destination, and Codex's `createHistoryForkDestination` now throws because generic history forks are routed through the native thread RPC. The throw unwinds through the promise chain into `ignoreResult`, so after the session was already stopped and the queue snapshot restored, the undo just stops: no truncation, no reload, no error to the client. The backup is auxiliary, so this PR skips it (with a warning) when the driver cannot provide a destination, and reports an exception out of the undo execution to the requesting client instead of letting it vanish.

The second failure follows on the next resume: the undo's kill-and-respawn replaces the task's session while the dead session's live history binding is still installed, because the superseded session's `onExit` returns before its cleanup runs. The next `resolveTaskHistory` then throws "Live history binding does not match the mapped session owner", and out of the post-undo resume nothing catches it, so the whole backend exits. A binding belongs to whichever session is currently mapped, so it is dropped at the point of replacement; the new session installs its own once it announces its native session id, and until then history resolves from configured context, the same as before a task's first session starts.

Both defects are only jointly observable (the second hides behind the first), which is why they arrive as one commit. `e2e-codex-undo-while-running-L10` fails before this change and passes after; the claude variant and the native-undo suites are unaffected. Full check set run per commit; a handful of contention flakes passed on serial retry.