### PR TITLE
fix(web): tighten the composer on narrow screens

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3747,6 +3747,25 @@ pre.extra-field-value {
 
 /* Responsive: narrow screens */
 @media (max-width: 768px) {
+  /* the composer eats a lot of a phone screen, so halve its spacing and give
+     the buttons equal padding on all four sides */
+  .input-box {
+    gap: 4px;
+    padding: 6px 8px;
+  }
+
+  .input-textarea {
+    padding: 5px 7px;
+    /* the 40px floor is one line's worth at the full padding; at half the
+       padding it would leave dead space under a single line until wrapping
+       outgrew it */
+    min-height: 30px;
+  }
+
+  .input-box .btn {
+    padding: 5px;
+  }
+
   .banner-usage {
     width: 132px;
     flex-basis: 132px;


### PR DESCRIPTION
The composer keeps its desktop spacing on a phone, where it takes a noticeable slice of the screen: 12px/16px around the box, 10px/14px inside the textarea, and buttons padded 10px/20px.

This halves that below 768px and gives the composer's buttons equal padding on all sides.

The textarea's `min-height: 40px` is one line's worth at the full padding, so it drops to 30px to match. Left alone it holds open roughly ten pixels of dead space under a single line, which disappears only once word wrap outgrows the floor, so the box looks correct while typing a long message and wrong while typing a short one.

Nothing outside the `max-width: 768px` block changes, so desktop layout is untouched.
