### PR TITLE
fix(web): stop the page dragging sideways on narrow screens

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -103,6 +103,11 @@ body,
   font-family: var(--font-sans);
   font-size: 15px;
   overscroll-behavior: none;
+  /* nothing here scrolls sideways at the document level: the panes that need
+     it scroll inside themselves, so any horizontal give is an overflowing
+     child dragging the whole page with it */
+  overflow-x: hidden;
+  max-width: 100%;
 }
 
 .app {
@@ -638,6 +643,9 @@ body,
   gap: 12px;
   font-size: 12px;
   margin-left: auto;
+  /* a flex item defaults to min-width:auto, so this cluster refuses to shrink
+     below its contents and widens the document past the viewport */
+  min-width: 0;
 }
 
 .banner-usage {
@@ -795,6 +803,11 @@ body,
 .banner-status {
   padding: 2px 8px;
   font-size: 12px;
+  /* the longest thing in the banner, and the one that can safely be clipped */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .banner-status.connected {


### PR DESCRIPTION
On a phone the whole page can be dragged sideways, header and all, with empty space appearing at the right edge.

The banner's right-hand cluster is what widens it. Measured at a 390px viewport, the rename button, status and theme toggle together occupy 509px, and since a flex item defaults to `min-width: auto` the cluster refuses to shrink below its contents, taking the document to 525px.

Letting it shrink, and letting the status text ellipsize, brings the document back to exactly the viewport width (measured: 525px to 390px).

`overflow-x: hidden` at the root is a backstop for the same class of problem: the panes that genuinely scroll sideways (code blocks, tables) scroll inside themselves, so horizontal give at the document level is always an overflowing child dragging the page rather than something worth panning.
