### PR TITLE
feat(web): attach images with a file picker, not just paste and drop

### DIFF
--- a/web/src/components/InputBox.attach.test.tsx
+++ b/web/src/components/InputBox.attach.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options { "pretendToBeVisual": true }
+ *
+ * The composer's attach button. Paste and drag-and-drop were the only ways to
+ * attach an image, which left phones with no way at all: iOS has no file drag
+ * source, and gecko-for-iOS does not put pasted photos on the DOM clipboard.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { InputBox } from "./InputBox";
+import {
+  createOrdinaryDraftStore,
+  type OrdinaryDraftStore,
+} from "../ordinaryDraftStore";
+
+vi.hoisted(() => {
+  vi.stubGlobal("CSS", { supports: () => false });
+});
+
+const SESSION = "attach-session";
+
+/** FileReader.readAsDataURL resolves on a task, so let it land. */
+const flushReader = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+async function mountComposer(
+  container: HTMLElement,
+  store: OrdinaryDraftStore,
+) {
+  await act(() => {
+    render(
+      <InputBox
+        onSend={() => {}}
+        onInterrupt={() => {}}
+        isProcessing={false}
+        stdinClosed={false}
+        disabled={false}
+        sessionId={SESSION}
+        ordinaryDraftStore={store}
+      />,
+      container,
+    );
+  });
+}
+
+/** A real File whose bytes decode as the given data URL payload. */
+function imageFile(name: string, type: string) {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type });
+}
+
+/** Drive the hidden input the way a picker selection does. */
+async function selectFiles(container: HTMLElement, files: File[]) {
+  const input = container.querySelector<HTMLInputElement>("input.input-file");
+  expect(input).not.toBeNull();
+  // a FileList stand-in: indexed access, length, item(), and iteration
+  const list: Record<string | number | symbol, unknown> = {
+    item: (index: number) => files[index] ?? null,
+    [Symbol.iterator]: files[Symbol.iterator].bind(files),
+  };
+  files.forEach((file, index) => {
+    list[index] = file;
+  });
+  list.length = files.length;
+  Object.defineProperty(input!, "files", { configurable: true, value: list });
+  await act(() => {
+    input!.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+describe("composer image attachment", () => {
+  let container: HTMLElement;
+  let store: OrdinaryDraftStore;
+
+  beforeEach(() => {
+    store = createOrdinaryDraftStore();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("offers an attach control that reaches the system picker", async () => {
+    await mountComposer(container, store);
+
+    const button = container.querySelector<HTMLButtonElement>(".btn-attach");
+    const input = container.querySelector<HTMLInputElement>("input.input-file");
+    expect(button).not.toBeNull();
+    expect(input).not.toBeNull();
+    // accept drives which picker iOS opens; multiple lets a batch through
+    expect(input!.getAttribute("accept")).toBe("image/*");
+    expect(input!.hasAttribute("multiple")).toBe(true);
+
+    let clicked = false;
+    input!.click = () => {
+      clicked = true;
+    };
+    await act(() => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(clicked).toBe(true);
+  });
+
+  it("attaches picked images as previews", async () => {
+    await mountComposer(container, store);
+    await selectFiles(container, [
+      imageFile("one.jpg", "image/jpeg"),
+      imageFile("two.png", "image/png"),
+    ]);
+    await act(async () => {
+      await flushReader();
+    });
+
+    expect(container.querySelectorAll(".image-preview img").length).toBe(2);
+  });
+
+  it("refuses image types the agent APIs reject, and says so", async () => {
+    await mountComposer(container, store);
+    await selectFiles(container, [imageFile("photo.heic", "image/heic")]);
+    await act(async () => {
+      await flushReader();
+    });
+
+    expect(container.querySelectorAll(".image-preview img").length).toBe(0);
+    const error = container.querySelector(".attach-error");
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toContain("image/heic");
+  });
+
+  it("clears the input so the same photo can be picked twice", async () => {
+    await mountComposer(container, store);
+    const input = container.querySelector<HTMLInputElement>("input.input-file");
+    await selectFiles(container, [imageFile("one.jpg", "image/jpeg")]);
+    await act(async () => {
+      await flushReader();
+    });
+    expect(input!.value).toBe("");
+  });
+});

--- a/web/src/components/InputBox.tsx
+++ b/web/src/components/InputBox.tsx
@@ -149,6 +149,16 @@ function publishImages(entry: ControlledImageEntry, images: ImageAttachment[]) {
   }
 }
 
+// what the agent APIs actually accept; an iPhone photo arrives as JPEG because
+// the picker transcodes it, but a file picked out of Files can still be HEIC,
+// and attaching one silently produces a send the API rejects
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
 function useImageAttachments(
   enabled = true,
   resetToken?: number,
@@ -168,6 +178,7 @@ function useImageAttachments(
     () => imageEntry?.generation ?? 0,
   );
   const [isDragging, setIsDragging] = useState(false);
+  const [attachError, setAttachError] = useState<string | null>(null);
   const enabledRef = useRef(enabled);
   const resetTokenRef = useRef(resetToken);
   const generationRef = useRef(imageEntry?.generation ?? 0);
@@ -234,6 +245,13 @@ function useImageAttachments(
 
   const processFile = (file: File) => {
     if (!enabledRef.current || !file.type.startsWith("image/")) return;
+    if (!SUPPORTED_IMAGE_TYPES.has(file.type)) {
+      setAttachError(
+        `${file.type} images can't be attached; JPEG, PNG, GIF and WebP work`,
+      );
+      return;
+    }
+    setAttachError(null);
     const generation = generationRef.current;
     const entry = imageEntry;
     const reader = new FileReader();
@@ -260,6 +278,11 @@ function useImageAttachments(
       setImagesGeneration(generation);
     };
     reader.readAsDataURL(file);
+  };
+
+  const addFiles = (files: FileList | File[] | null) => {
+    if (!files) return;
+    for (const file of Array.from(files)) processFile(file);
   };
 
   const onPaste = (event: ClipboardEvent) => {
@@ -314,11 +337,94 @@ function useImageAttachments(
     images: enabled && imagesGeneration === generationRef.current ? images : [],
     setImages,
     isDragging: enabled && isDragging,
+    attachError,
+    dismissAttachError: () => {
+      setAttachError(null);
+    },
+    addFiles,
     onPaste,
     onDragOver,
     onDragLeave,
     onDrop,
   };
+}
+
+/** Attach button plus the hidden input it drives.
+ *
+ * Paste and drag-and-drop were the only ways to attach an image, and a phone
+ * has neither: iOS has no file drag source, and gecko-for-iOS does not put
+ * pasted photos on the DOM clipboard. A plain file input is what reaches the
+ * system photo picker there.
+ *
+ * The input is visually hidden rather than display:none, since only the former
+ * is reliably clickable programmatically across engines.
+ */
+function AttachButton({
+  disabled,
+  onFiles,
+}: {
+  disabled: boolean;
+  onFiles: (files: FileList | null) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input
+        ref={inputRef}
+        class="input-file"
+        type="file"
+        accept="image/*"
+        multiple
+        tabIndex={-1}
+        aria-hidden="true"
+        onChange={(event) => {
+          const input = event.target as HTMLInputElement;
+          onFiles(input.files);
+          // clearing lets the same photo be picked again right after removing it
+          input.value = "";
+        }}
+      />
+      <button
+        key="attach"
+        class="btn btn-attach"
+        title="Attach images"
+        aria-label="Attach images"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+      >
+        {/* drawn rather than typed: an emoji is a font glyph, so its artwork
+            changes per platform and its advance width adds side bearings that
+            no padding rule can reclaim. drawn upright, and the viewBox is
+            cropped to the artwork's width so the button is exactly as wide as
+            the clip */}
+        <svg
+          viewBox="5 0 14 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M17 5.75v10.85a5 5 0 0 1-10 0V5.75a3.35 3.35 0 0 1 6.7 0v10.85a1.65 1.65 0 0 1-3.3 0V6.6" />
+        </svg>
+      </button>
+    </>
+  );
+}
+
+function AttachError({
+  message,
+  onDismiss,
+}: {
+  message: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <div class="attach-error" role="status" onClick={onDismiss}>
+      {message}
+    </div>
+  );
 }
 
 function ImagePreviews({
@@ -425,6 +531,9 @@ function OrdinaryInputBox({
     onDragOver,
     onDragLeave,
     onDrop,
+    attachError,
+    dismissAttachError,
+    addFiles,
   } = useImageAttachments();
 
   const saveDraftDebounced = useMemo(
@@ -593,6 +702,9 @@ function OrdinaryInputBox({
           setImages((previous) => previous.filter((image) => image.id !== id));
         }}
       />
+      {attachError && (
+        <AttachError message={attachError} onDismiss={dismissAttachError} />
+      )}
       <textarea
         key="textarea"
         ref={textareaRef}
@@ -610,6 +722,7 @@ function OrdinaryInputBox({
         disabled={disabled}
         rows={1}
       />
+      <AttachButton disabled={disabled || !!stdinClosed} onFiles={addFiles} />
       {isProcessing && (
         <button key="stop" class="btn btn-stop" onClick={onInterrupt}>
           Stop
@@ -655,6 +768,9 @@ function ControlledInputBox({
     onDragOver,
     onDragLeave,
     onDrop,
+    attachError,
+    dismissAttachError,
+    addFiles,
   } = useImageAttachments(!disabled, composerResetToken, imageStore, imageKey);
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = inputRef ?? internalRef;
@@ -754,6 +870,9 @@ function ControlledInputBox({
           setImages((previous) => previous.filter((image) => image.id !== id));
         }}
       />
+      {attachError && (
+        <AttachError message={attachError} onDismiss={dismissAttachError} />
+      )}
       <textarea
         key="textarea"
         ref={textareaRef}
@@ -769,6 +888,7 @@ function ControlledInputBox({
         disabled={disabled}
         rows={1}
       />
+      <AttachButton disabled={disabled || !!stdinClosed} onFiles={addFiles} />
       {isProcessing && (
         <button key="stop" class="btn btn-stop" onClick={onInterrupt}>
           Stop

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -834,6 +834,60 @@ body,
   overflow-anchor: none;
 }
 
+/* Attach button: visually hidden input, since display:none is not reliably
+   clickable from script across engines */
+.input-file {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* the glyph is the control: no chrome, no inner spacing, sized against the
+   send button beside it. .btn.btn-attach rather than .btn-attach, since the
+   generic .btn rule is declared later in this file and would otherwise win on
+   order alone */
+.btn.btn-attach {
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  line-height: 0;
+  color: var(--text-dim);
+  opacity: 0.8;
+}
+
+.btn.btn-attach:hover:not(:disabled) {
+  opacity: 1;
+}
+
+.btn.btn-attach:disabled {
+  opacity: 0.3;
+}
+
+/* an svg has no side bearings, so the box is exactly the icon: the same
+   height as the send button beside it, width from the viewBox ratio */
+.btn.btn-attach svg {
+  width: auto;
+  height: var(--composer-btn-h);
+  display: block;
+}
+
+.input-box .btn-send,
+.input-box .btn-stop {
+  height: var(--composer-btn-h);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.attach-error {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
 /* Message wrapper (action buttons) */
 .message-wrapper {
   position: relative;
@@ -1637,6 +1691,9 @@ body,
 
 /* Input box */
 .input-box {
+  /* one height for the send button and the attach icon, so they always match
+     exactly; 36px is the send button's natural height at this padding */
+  --composer-btn-h: 36px;
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
@@ -1678,7 +1735,11 @@ body,
 
 .input-textarea {
   flex: 1;
-  padding: 10px 14px;
+  /* 9 + 16 + 9 + 2px border = exactly --composer-btn-h (36px), so a
+     single-line box matches the buttons beside it with the text centered;
+     the explicit line-height keeps that true across font metrics */
+  padding: 9px 14px;
+  line-height: 16px;
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
@@ -1687,7 +1748,7 @@ body,
   resize: none;
   outline: none;
   overflow-y: auto;
-  min-height: 40px;
+  min-height: var(--composer-btn-h);
   max-height: 200px;
   field-sizing: content;
 }


### PR DESCRIPTION
The composer accepts images by paste and by drag-and-drop, which between them cover a desktop and nothing else. A phone has no file drag source, and mobile browsers do not reliably put a photo on the DOM clipboard, so there is currently no way to attach an image from one at all.

This adds an attach control backed by a hidden file input (`accept="image/*"`, `multiple`), which is what reaches the system photo picker.

Details worth knowing:

- The input is visually hidden rather than `display: none`, since only the former is reliably clickable from script across engines, and it is cleared after each selection so the same photo can be picked again after being removed.
- Image types outside JPEG, PNG, GIF and WebP are refused with a message in the composer instead of being attached. The media type goes to the agent API verbatim, so a HEIC attaches fine and then fails at send time; a photo picked out of a file manager can still be HEIC even where the camera path transcodes to JPEG.
- The control is an upright paperclip drawn as an inline `svg` in the same idiom as the sidebar's icons: it takes its colour from the theme and renders identically everywhere, its viewBox is cropped to the artwork so the button is exactly as wide as the clip, and its height comes from the same custom property that now sizes the send and stop buttons and the single-line textarea (the buttons center their labels with flex; the textarea's padding and line-height sum to the same height), so every control in the composer row matches exactly by construction.

Covered by unit tests for the picker wiring, preview creation, the unsupported-type refusal, and re-picking the same file twice.

One of five independent changes for using cydo on a phone: #15 (composer spacing), #16 (the page dragging sideways), #17 (hiding the composer while reading history), #19 (replaying a window of history, with older messages on demand). They touch different code and can merge in any order.